### PR TITLE
dt. -> Dt.

### DIFF
--- a/manuscript/00-definitionen.md
+++ b/manuscript/00-definitionen.md
@@ -3,18 +3,18 @@
 ### Domain {#domain}
 
 Ein Bereich von Wissen, Einfluss oder Aktivität. Das Fachgebiet, auf
-das der Benutzer ein Programm anwendet, ist die *Domain* (dt.: Domäne)
+das der Benutzer ein Programm anwendet, ist die *Domain* (Dt.: Domäne)
 der Software.
 
 ### Model {#model}
 
-Ein *Model* (dt.: Modell) ist ein System von Abstraktionen, das
+Ein *Model* (Dt.: Modell) ist ein System von Abstraktionen, das
 ausgewählte Aspekte einer Domain beschreibt und zur Lösung von
 Problemen im Zusammenhang mit dieser Domain verwendet werden kann.
 
 ### Ubiquitous Language
 
-Die [*Ubiquitous Language*](#ubiquitous-language) (dt.:
+Die [*Ubiquitous Language*](#ubiquitous-language) (Dt.:
 allgegenwärtige Sprache) ist eine
 Sprache, die um das Domänenmodell herum gruppiert ist und von allen
 Teammitgliedern in einem *Bounded Context* verwendet wird, um alle
@@ -24,11 +24,11 @@ Aktivitäten des Teams mit der Software zu verbinden.
 
 Der Bereich, in dem ein Wort oder eine Aussage auftaucht und der dabei
 ihre Bedeutung bestimmt.  *Aussagen über ein Modell können nur in
-einem Context (dt.: Kontext) verstanden werden.*
+einem Context (Dt.: Kontext) verstanden werden.*
 
 ### Bounded Context
 
-Der [*Bounded Context*](#bounded-context) (dt.: begrenzter Kontext)
+Der [*Bounded Context*](#bounded-context) (Dt.: begrenzter Kontext)
 ist eine Beschreibung
 einer Grenze (typischerweise ein Subsystem oder die Arbeit eines
 bestimmten Teams), innerhalb derer ein bestimmtes Modell definiert und

--- a/manuscript/01-das-modell-zum-einsatz-bringen.md
+++ b/manuscript/01-das-modell-zum-einsatz-bringen.md
@@ -28,7 +28,7 @@ Design.
 
 ## Bounded Context {#bounded-context}
 
-*dt.: Begrenzter Kontext*
+*Dt.: Begrenzter Kontext*
 
 *Bei jedem großen Projekt sind mehrere Modelle im Spiel.* Sie
 entstehen aus vielen Gründen. Zwei Subsysteme bedienen in der Regel
@@ -63,7 +63,7 @@ anderswo nicht verwendet werden muss.**
 
 ## Ubiquitous Language {#ubiquitous-language}
 
-*dt.: allgegenwärtige Sprache*
+*Dt.: allgegenwärtige Sprache*
 
 Zuerst schreibst du einen Satz,  
 Und dann hackst du ihn klein;  
@@ -167,7 +167,7 @@ Daher:
 
 ## Model-Driven Design {#model-driven-design}
 
-*dt.: modellgetriebener Entwurf*
+*Dt.: modellgetriebener Entwurf*
 
 *Die enge Verknüpfung des Codes mit einem zugrunde liegenden Modell
 gibt dem Code einen Sinn und macht das Modell relevant.*
@@ -208,7 +208,7 @@ unterstützt.**
 
 ## Hands-on Modelers {#hands-on-modelers}
 
-*dt.: Praktizierende Modellierer*
+*Dt.: Praktizierende Modellierer*
 
 Wenn sich die Personen, die den Code schreiben, nicht für das Modell
 verantwortlich fühlen oder nicht verstehen, wie das Modell für eine
@@ -245,7 +245,7 @@ Language](#ubiquitous-language) einbeziehen.**
 
 ## Refactoring Toward Deeper Insight {#refactoring-toward-deeper-insight}
 
-*dt.: Refactoring zum tieferen Verständnis*
+*Dt.: Refactoring zum tieferen Verständnis*
 
 Die Verwendung eines bewährten Satzes von Grundbausteinen zusammen mit
 einer konsistenten Sprache bringt ein wenig Vernunft in die

--- a/manuscript/02-bestandteile-eines-modellgetriebenen-designs.md
+++ b/manuscript/02-bestandteile-eines-modellgetriebenen-designs.md
@@ -11,7 +11,7 @@ Implementierung zu halten.
 
 ## Layered Architecture {#layered-architecture}
 
-*dt.: Geschichtete Architektur*
+*Dt.: Geschichtete Architektur*
 
 In einem objekt-orientierten Programm werden Benutzeroberfläche,
 Datenbank und anderer unterstützender Code oft direkt in den
@@ -58,7 +58,7 @@ auf und Referenzen zu anderen Systembelangen vermeiden.
 
 ## Entities {#entity}
 
-*dt.: Entitäten*
+*Dt.: Entitäten*
 
 Viele Objekte stellen eine Kontinuität und Identität dar und
 durchlaufen einen Lebenszyklus, obwohl sich ihre Attribute ändern
@@ -94,11 +94,11 @@ Identitätsunterschieden im Modell passen.**
 **Das Modell muss definieren, was es bedeutet, dasselbe Ding zu
 sein.**
 
-(auch bekannt als Reference Objects, dt.: Referenzobjekte)
+(auch bekannt als Reference Objects, Dt.: Referenzobjekte)
 
 ## Value Objects {#value-object}
 
-*dt.: Wertobjekte*
+*Dt.: Wertobjekte*
 
 Einige Objekte beschreiben oder berechnen eine Eigenschaft eines Dings.
 
@@ -132,7 +132,7 @@ Entities notwendig sind.**
 
 ## Domain Event {#domain-event}
 
-*dt.: Domänenereignis*
+*Dt.: Domänenereignis*
 
 Etwas ist passiert, was für Domänenexperten wichtig ist.
 
@@ -200,7 +200,7 @@ werden.
 
 ## Services {#service}
 
-*dt.: Dienste*
+*Dt.: Dienste*
 
 Manchmal ist es einfach kein Ding.
 
@@ -228,7 +228,7 @@ wird.**
 
 ## Modules {#module}
 
-*dt.: Module*
+*Dt.: Module*
 
 Jeder verwendet Module, aber nur wenige behandeln sie als
 vollwertigen Teil des Modells. Code wird in alle möglichen Kategorien
@@ -264,11 +264,11 @@ können. Verfeinere das Modell, bis es nach
 hochwertigen Domänenkonzepten partitioniert ist und auch der Code
 entsprechend entkoppelt ist.**
 
-(auch bekannt als Packages, dt.: Pakete)
+(auch bekannt als Packages, Dt.: Pakete)
 
 ## Aggregates {#aggregate}
 
-*dt.: Aggregate*
+*Dt.: Aggregate*
 
 Es ist schwierig, die Konsistenz von Änderungen an Objekten in einem
 Modell mit komplexen Beziehungen zu gewährleisten. Objekte sollen
@@ -360,7 +360,7 @@ Objekte und den Zugriff auf die Objekte an die Repositories.**
 
 ## Factories {#factory}
 
-*dt.: Fabriken*
+*Dt.: Fabriken*
 
 Wenn die Erstellung eines ganzen, intern konsistenten
 [Aggregats](#aggregate) oder eines großen [Value Objects](#value-object)

--- a/manuscript/04-context-mapping-fuer-strategic-design.md
+++ b/manuscript/04-context-mapping-fuer-strategic-design.md
@@ -2,7 +2,7 @@
 
 ### Bounded Context
 
-Der [Bounded Context](#bounded-context) (dt.: begrenzter Kontext)
+Der [Bounded Context](#bounded-context) (Dt.: begrenzter Kontext)
 ist eine Beschreibung
 einer Grenze (typischerweise ein Subsystem oder die Arbeit eines
 bestimmten Teams), innerhalb derer ein bestimmtes Modell definiert und
@@ -14,16 +14,16 @@ Eine Beziehung zwischen zwei Gruppen, in der die Handlungen der
 "Upstream"-Gruppe den Projekterfolg der "Downstream"-Gruppe
 beeinflussen, während die Handlungen der Downstream-Gruppe die
 Upstream-Projekte nicht wesentlich beeinflussen. (Wenn zwei Städte am
-gleichen Fluss liegen, wirkt sich die Verschmutzung der upstream (dt.:
+gleichen Fluss liegen, wirkt sich die Verschmutzung der upstream (Dt.:
 flussaufwärts) gelegenen Stadt in erster Linie auf die downstream
-gelegene Stadt (dt.: flussabwärts) aus).
+gelegene Stadt (Dt.: flussabwärts) aus).
 
 Das Upstream-Team kann unabhängig vom Schicksal des Downstream-Teams
 erfolgreich sein.
 
 ### Mutually Dependent {#mutually-dependent}
 
-Mutually Dependent (dt.: wechselseitig abhängig) beschreibt eine Situation,
+Mutually Dependent (Dt.: wechselseitig abhängig) beschreibt eine Situation,
 in der zwei Softwareentwicklungsprojekte in getrennten Kontexten
 beide liefern müssen, damit jedes von beiden als erfolgreich angesehen
 werden können. 
@@ -42,14 +42,14 @@ System nicht ausgeliefert wird.
 
 ### Free {#free}
 
-Ein Softwareentwicklungskontext ist free (dt.: frei), wenn die
+Ein Softwareentwicklungskontext ist free (Dt.: frei), wenn die
 Ausrichtung, der Erfolg oder das Scheitern der Entwicklungsarbeit in
 anderen Kontexten wenig Einfluss auf die Auslieferung dieses Konext
 hat.
 
 ## Context Map {#context-map}
 
-*dt.: Kontext-Karte*
+*Dt.: Kontext-Karte*
 
 *Um die Strategie zu planen, benötigen wir eine realistische, groß
 angelegte Sicht auf die Modellentwicklung, die sich über unser
@@ -100,7 +100,7 @@ zwischen [Bounded Contexts](#bounded-context).
 
 ## Partnership {#partnership}
 
-*dt.: Partnerschaft*
+*Dt.: Partnerschaft*
 
 *Wenn Teams in zwei Kontexten gemeinsam erfolgreich sind oder
 scheitern, entsteht oft eine kooperative Beziehung.*
@@ -153,7 +153,7 @@ blauen Buch aus dem Jahre
 
 ## Shared Kernel {#shared-kernel}
 
-*dt.: Gemeinsamer Kern*
+*Dt.: Gemeinsamer Kern*
 
 *Die gemeinsame Nutzung eines Teils des Modells und des zugehörigen
 Codes erzeugen eine sehr enge wechselseitige Abhängigkeit, die der
@@ -205,7 +205,7 @@ der Teams.
 
 ## Customer/Supplier Development {#customer-supplier}
 
-*dt.: Kunde / Zulieferer*
+*Dt.: Kunde / Zulieferer*
 
 *Wenn sich zwei Teams in einer
 [Upstream-Downstream-Beziehung](#upstream-downstream)
@@ -245,7 +245,7 @@ zu haben.
 
 ## Conformist {#conformist}
 
-*dt.: Konformist*
+*Dt.: Konformist*
 
 Wenn zwei Entwicklungsteams eine Upstream/Downstream-Beziehung haben,
 in der Upstream keine Motivation hat, den Bedürfnisse des
@@ -277,7 +277,7 @@ dazu zu bringen, Informationen mit dir zu teilen.**
 
 ## Anticorruption-Layer {#anticorruption-layer}
 
-*dt.: Antikorruptionsschicht*
+*Dt.: Antikorruptionsschicht*
 
 Übersetzungsschichten können einfach, ja sogar elegant sein, wenn es
 darum geht, gut gestaltete [Bounded Context](#bounded-context)
@@ -312,7 +312,7 @@ den beiden Modellen.**
 
 ## Open-host Service {#open-host-service}
 
-*dt.: Offener Host*
+*Dt.: Offener Host*
 
 *Typischerweise definierst du für jeden [Bounded
 Context](#bounded-context) eine
@@ -349,7 +349,7 @@ Kontexten haben, die nicht seine Clients sind.
 
 ## Published Language {#published-language}
 
-*dt.: veröffentlichte Sprache*
+*Dt.: veröffentlichte Sprache*
 
 *Die Übersetzung zwischen den Modellen zweier [Bounded
 Contexts](#bounded-context)
@@ -380,7 +380,7 @@ Service](#open-host-service) kombiniert.
 
 ## Separate Ways {#separate-ways}
 
-*dt.: Getrennte Wege*
+*Dt.: Getrennte Wege*
 
 Wir müssen rücksichtslos sein, wenn es um die Definition von
 Anforderungen geht.  Wenn zwei Mengen von Funktionalitäten keine
@@ -398,7 +398,7 @@ diesem kleinen Bereich finden können.**
 
 ## Big Ball of Mud {#big-ball-of-mud}
 
-*dt.: Großer Schlammball*
+*Dt.: Großer Schlammball*
 
 Wenn wir bestehende Softwaresysteme untersuchen und versuchen zu
 verstehen, wie unterschiedliche Modelle innerhalb definierter Grenzen


### PR DESCRIPTION
IMHO sollte es Dt. sein, weil wir von Deutsch als der deutschen Sprache sprechen, siehe https://www.duden.de/rechtschreibung/deutsch Absatz 2a