### PR TITLE
Kleinere Formulierungsänderungsvorschläge

### DIFF
--- a/manuscript/04-context-mapping-fuer-strategic-design.md
+++ b/manuscript/04-context-mapping-fuer-strategic-design.md
@@ -119,7 +119,7 @@ Entwicklung und zum gemeinsamen Managements der Integration ein.**
 
 **Die Teams müssen bei der Entwicklung ihrer Schnittstellen
 zusammenarbeiten, um die Bedürfnisse bei der Entwicklung beider
-Systeme zu befriedigen. Voneinander abhängige Funktionalitäten sollten so
+Systeme zu berücksichtigen. Voneinander abhängige Funktionalitäten sollten so
 eingeplant werden, dass sie auf das gleiche Release hin abgeschlossen
 werden.**
 
@@ -294,8 +294,8 @@ den beiden Modellen.**
 
 *Dt.: Offen angebotener Dienst*
 
-*Typischerweise definierst du für jeden [Bounded Context](#bounded-context) eine
-Übersetzungsschicht für jede Komponente, mit der du integrieren musst
+*Typischerweise definierst du für jeden [Bounded Context](#bounded-context)
+und jede Komponente eine Übersetzungsschicht, mit der du integrieren musst
 und die außerhalb des Kontextes liegt. Wenn jede Integration anders
 ist, vermeidet dieser Ansatz mit einer Übersetzungsschicht für jedes
 externe System die Korruption der Modelle mit minimalen
@@ -379,7 +379,7 @@ diesem kleinen Bereich finden können.**
 Wenn wir bestehende Softwaresysteme untersuchen und versuchen zu
 verstehen, wie unterschiedliche Modelle innerhalb definierter Grenzen
 angewendet werden, finden wir Teile von Systemen, oft große, in denen
-Modelle gemischt sind und Grenzen inkonsistent sind.
+Modelle gemischt und Grenzen inkonsistent sind.
 
 Es ist leicht, beim Versuch festzufahren, die Kontextgrenzen
 von Modellen in Systemen zu beschreiben, in denen es einfach keine

--- a/manuscript/05-destillieren-fuer-strategic-design.md
+++ b/manuscript/05-destillieren-fuer-strategic-design.md
@@ -43,7 +43,7 @@ Ganzes zu destillieren.
 
 In einem großen System gibt es so viele Komponenten, die alle
 kompliziert und absolut notwendig für den Erfolg sind, dass die Essenz
-des Domänenmodells, der eigentliche Unternehmenswert, unklar sein kann
+des Domänenmodells, der eigentliche Unternehmenswert, unklar sein
 und dann vernachlässigt werden kann.
 
 Die harte Realität ist, dass nicht alle Teile des Entwurfs gleich
@@ -68,8 +68,8 @@ rekrutiere entsprechend. Investiere den Aufwand, um ein
 tiefgreifendes Modell zu finden und ein flexibles Design zu
 entwickeln, das ausreicht, um die Vision des Systems zu erfüllen.**
 
-**Rechtfertige die Investition in andere Teile, indem du betrachtest,
-wie sie den destillierten Kern unterstützen.**
+Rechtfertige die Investition in andere Teile, indem du betrachtest,
+wie sie den destillierten Kern unterstützen.
 
 ## Generic Subdomains {#generic-subdomain}
 
@@ -105,7 +105,7 @@ Domänenwissen gewinnen). Erwäge auch Standardlösungen oder
 Zu Beginn eines Projekts existiert das Modell in der Regel noch gar
 nicht, aber seine Entwicklung muss schon fokussiert werden. In
 späteren Entwicklungsstadien muss der Wert des Systems erklärt werden,
-ohne dass man dazu das Modells eingehend studieren muss. Auch können
+ohne dass man dazu das Modell eingehend studieren muss. Auch können
 sich kritische Aspekte des Domänenmodells über mehrere [Bounded
 Contexts](#bounded-context) erstrecken, aber per Definition können
 diese unterschiedlichen Modelle nicht so strukturiert werden, dass sie 

--- a/manuscript/06-grobe-struktur-fuer-strategic-design.md
+++ b/manuscript/06-grobe-struktur-fuer-strategic-design.md
@@ -63,10 +63,10 @@ achten, sondern
 eine minimale Menge zu finden, welche die aufgetretenen Probleme löst.
 Weniger ist mehr.**
 
-Was folgt, ist eine Reihe von vier speziellen Mustern für die
+**Was folgt, ist eine Reihe von vier speziellen Mustern für die
 [Large-scale Structure](#large-scale-structure),
 die bei einigen Projekten entstehen und für diese Art von
-Muster repräsentativ sind.
+Muster repräsentativ sind.**
 
 ## System Metaphor {#system-metaphor}
 


### PR DESCRIPTION
Die Übersetzung ist ja [absichtlich nah am Original übersetzt](https://github.com/ddd-referenz/ddd-referenz/issues/36#issuecomment-458848957), dennoch habe ich einige Kleinigkeiten gefunden, die ich als Änderungsvorschlag einreichen möchte:

* Texte _subjektiv_ angenehmer zum lesen gemacht, d.h. doppelte Worte ("X kann und Y kann" zu "X und Y kann") vereinfacht
* Texthervorhebung ans Original angepasst, d.h. Fettdruck hinzugefügt wo Text im Original auch fett gedruckt war und in der Übersetzung nicht